### PR TITLE
Fix Get-FilesList

### DIFF
--- a/Functions/FoldersFiles/Get-FilesList.ps1
+++ b/Functions/FoldersFiles/Get-FilesList.ps1
@@ -53,7 +53,9 @@
 		#$PACLI variable set to executable path
 
 		#execute pacli
-		$Return = Invoke-PACLICommand $pacli FILESLIST "$($PSBoundParameters.getEnumerator() | ConvertTo-ParameterString) OUTPUT (ALL,ENCLOSE)"
+		$Return = Invoke-PACLICommand $pacli FILESLIST "$($PSBoundParameters.getEnumerator() |
+
+		ConvertTo-ParameterString) OUTPUT (ALL,ENCLOSE)" -DoNotWait
 
 		if($Return.ExitCode) {
 


### PR DESCRIPTION
Resolved issue where Get-FilesList was not returning results. Pacli
execution set to not wait for exit for this command.

Relates to #21 