### PR TITLE
Issue 23

### DIFF
--- a/Functions/FoldersFiles/New-PVFolder.ps1
+++ b/Functions/FoldersFiles/New-PVFolder.ps1
@@ -32,7 +32,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -59,11 +59,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Folder $folder Created"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/FoldersFiles/Remove-PVFile.ps1
+++ b/Functions/FoldersFiles/Remove-PVFile.ps1
@@ -70,8 +70,6 @@
 
 			Write-Verbose "$file Removed"
 
-
-
 		}
 
 	}

--- a/Functions/FoldersFiles/Remove-PVFile.ps1
+++ b/Functions/FoldersFiles/Remove-PVFile.ps1
@@ -38,7 +38,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -66,11 +66,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "$file Removed"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/FoldersFiles/Remove-PVFileCategory.ps1
+++ b/Functions/FoldersFiles/Remove-PVFileCategory.ps1
@@ -39,7 +39,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -68,11 +68,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "File Category $category Deleted"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/FoldersFiles/Remove-PVFolder.ps1
+++ b/Functions/FoldersFiles/Remove-PVFolder.ps1
@@ -64,8 +64,6 @@
 
 			Write-Verbose "Folder $folder Deleted"
 
-
-
 		}
 
 	}

--- a/Functions/FoldersFiles/Remove-PVFolder.ps1
+++ b/Functions/FoldersFiles/Remove-PVFolder.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -60,11 +60,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Folder $folder Deleted"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/FoldersFiles/Remove-PVPreferredFolder.ps1
+++ b/Functions/FoldersFiles/Remove-PVPreferredFolder.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -60,11 +60,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Preferred Folder $folder Removed"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/FoldersFiles/Remove-PVRule.ps1
+++ b/Functions/FoldersFiles/Remove-PVRule.ps1
@@ -79,8 +79,6 @@
 
 			Write-Verbose "Rule $RuleID Deleted"
 
-
-
 		}
 
 	}

--- a/Functions/FoldersFiles/Remove-PVRule.ps1
+++ b/Functions/FoldersFiles/Remove-PVRule.ps1
@@ -44,7 +44,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -75,11 +75,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Rule $RuleID Deleted"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/FoldersFiles/Reset-PVFile.ps1
+++ b/Functions/FoldersFiles/Reset-PVFile.ps1
@@ -36,7 +36,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -64,11 +64,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "File $file Reset"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/FoldersFiles/Set-PVFileCategory.ps1
+++ b/Functions/FoldersFiles/Set-PVFileCategory.ps1
@@ -42,7 +42,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -72,10 +72,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "File Category $category Updated"
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/FoldersFiles/Set-PVObjectValidation.ps1
+++ b/Functions/FoldersFiles/Set-PVObjectValidation.ps1
@@ -86,8 +86,6 @@
 
 			Write-Verbose "File $file Marked as $ValidationAction"
 
-
-
 		}
 
 	}

--- a/Functions/FoldersFiles/Set-PVObjectValidation.ps1
+++ b/Functions/FoldersFiles/Set-PVObjectValidation.ps1
@@ -50,7 +50,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -82,11 +82,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "File $file Marked as $ValidationAction"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/NetworkAreas/New-PVNetworkArea.ps1
+++ b/Functions/NetworkAreas/New-PVNetworkArea.ps1
@@ -62,11 +62,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Network Area $networkArea Created"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/NetworkAreas/New-PVNetworkArea.ps1
+++ b/Functions/NetworkAreas/New-PVNetworkArea.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/NetworkAreas/New-PVNetworkAreaAddress.ps1
+++ b/Functions/NetworkAreas/New-PVNetworkAreaAddress.ps1
@@ -39,7 +39,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/NetworkAreas/New-PVNetworkAreaAddress.ps1
+++ b/Functions/NetworkAreas/New-PVNetworkAreaAddress.ps1
@@ -69,11 +69,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Address Added to Network Area $networkArea"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/NetworkAreas/Remove-PVNetworkArea.ps1
+++ b/Functions/NetworkAreas/Remove-PVNetworkArea.ps1
@@ -30,7 +30,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -56,11 +56,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Network Area $networkArea Deleted"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/NetworkAreas/Remove-PVNetworkArea.ps1
+++ b/Functions/NetworkAreas/Remove-PVNetworkArea.ps1
@@ -60,8 +60,6 @@
 
 			Write-Verbose "Network Area $networkArea Deleted"
 
-
-
 		}
 
 	}

--- a/Functions/NetworkAreas/Remove-PVNetworkAreaAddress.ps1
+++ b/Functions/NetworkAreas/Remove-PVNetworkAreaAddress.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/NetworkAreas/Remove-PVNetworkAreaAddress.ps1
+++ b/Functions/NetworkAreas/Remove-PVNetworkAreaAddress.ps1
@@ -60,11 +60,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Address $ipAddress Removed from Network Area $networkArea"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/NetworkAreas/Remove-PVTrustedNetworkArea.ps1
+++ b/Functions/NetworkAreas/Remove-PVTrustedNetworkArea.ps1
@@ -64,8 +64,6 @@
 
 			Write-Verbose "Trusted Network Area $NetworkArea Removed from $trusterName"
 
-
-
 		}
 
 	}

--- a/Functions/NetworkAreas/Remove-PVTrustedNetworkArea.ps1
+++ b/Functions/NetworkAreas/Remove-PVTrustedNetworkArea.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -60,11 +60,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Trusted Network Area $NetworkArea Removed from $trusterName"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Passwords/New-PVPassword.ps1
+++ b/Functions/Passwords/New-PVPassword.ps1
@@ -98,7 +98,6 @@
 			if($Return.StdOut) {
 
 				Write-Verbose "Password Generated"
-				Write-Debug $Return.StdOut
 
 				#Return Generated Password String
 				[PSCustomObject] @{

--- a/Functions/Passwords/New-PVPassword.ps1
+++ b/Functions/Passwords/New-PVPassword.ps1
@@ -59,7 +59,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)]
 		[ValidateRange(1, 170)][int]$length,

--- a/Functions/Requests/Remove-PVRequest.ps1
+++ b/Functions/Requests/Remove-PVRequest.ps1
@@ -68,8 +68,6 @@
 
 			Write-Verbose "Request $RequestID Deleted"
 
-
-
 		}
 
 	}

--- a/Functions/Requests/Remove-PVRequest.ps1
+++ b/Functions/Requests/Remove-PVRequest.ps1
@@ -36,7 +36,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -64,11 +64,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Request $RequestID Deleted"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Requests/Set-PVRequestStatus.ps1
+++ b/Functions/Requests/Set-PVRequestStatus.ps1
@@ -19,7 +19,7 @@
     .PARAMETER requestID
         The unique ID number of the request.
 
-    .PARAMETER confirm
+    .PARAMETER confirmRequest
         Whether to confirm or reject this request.
 
     .PARAMETER reason
@@ -39,13 +39,13 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
 		[Parameter(Mandatory = $True)][string]$safe,
 		[Parameter(Mandatory = $True)][int]$requestID,
-		[Parameter(Mandatory = $True)][switch]$confirm,
+		[Parameter(Mandatory = $True)][switch]$confirmRequest,
 		[Parameter(Mandatory = $False)][string]$reason,
 		[Parameter(Mandatory = $False)][int]$sessionID
 	)
@@ -61,10 +61,8 @@
 		#$PACLI variable set to executable path
 
 		#ConvertTo-ParameterString usually remove "Confirm", which conflists with a parameter of the function
-		$Return = Invoke-PACLICommand $pacli CONFIRMREQUEST "$($PSBoundParameters.getEnumerator() |
-		ConvertTo-ParameterString -doNotQuote requestID -excludedParameters @("Debug", "ErrorAction",
-		"ErrorVariable", "OutVariable", "OutBuffer", "PipelineVariable", "Verbose", "WarningAction",
-		"WarningVariable", "WhatIf")) OUTPUT (ALL,ENCLOSE)"
+		$Return = Invoke-PACLICommand $pacli CONFIRMREQUEST "$($($PSBoundParameters.getEnumerator() |
+		ConvertTo-ParameterString -doNotQuote requestID) -replace "confirmRequest","confirm") OUTPUT (ALL,ENCLOSE)"
 
 		if($Return.ExitCode) {
 

--- a/Functions/Safes/Clear-PVSafeHistory.ps1
+++ b/Functions/Safes/Clear-PVSafeHistory.ps1
@@ -58,7 +58,7 @@
 
 		else {
 
-			"Cleared Safe History on Safe $safe"
+			Write-Verbose "Cleared Safe History on Safe $safe"
 
 			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 

--- a/Functions/Safes/New-PVSafe.ps1
+++ b/Functions/Safes/New-PVSafe.ps1
@@ -254,11 +254,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Safe Created: $safe"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Safes/New-PVSafe.ps1
+++ b/Functions/Safes/New-PVSafe.ps1
@@ -180,7 +180,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/Safes/New-PVSafeFileCategory.ps1
+++ b/Functions/Safes/New-PVSafeFileCategory.ps1
@@ -51,7 +51,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/Safes/New-PVSafeFileCategory.ps1
+++ b/Functions/Safes/New-PVSafeFileCategory.ps1
@@ -84,10 +84,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Added Safe File Category $category"
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Safes/Remove-PVSafe.ps1
+++ b/Functions/Safes/Remove-PVSafe.ps1
@@ -36,7 +36,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -62,11 +62,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted Safe $safe"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Safes/Remove-PVSafe.ps1
+++ b/Functions/Safes/Remove-PVSafe.ps1
@@ -66,8 +66,6 @@
 
 			Write-Verbose "Deleted Safe $safe"
 
-
-
 		}
 
 	}

--- a/Functions/Safes/Remove-PVSafeFileCategory.ps1
+++ b/Functions/Safes/Remove-PVSafeFileCategory.ps1
@@ -65,8 +65,6 @@
 
 			Write-Verbose "Deleted Safe File Category $category"
 
-
-
 		}
 
 	}

--- a/Functions/Safes/Remove-PVSafeFileCategory.ps1
+++ b/Functions/Safes/Remove-PVSafeFileCategory.ps1
@@ -34,7 +34,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -61,11 +61,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted Safe File Category $category"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Safes/Remove-PVSafeOwner.ps1
+++ b/Functions/Safes/Remove-PVSafeOwner.ps1
@@ -35,7 +35,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -62,10 +62,10 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Removed Safe Owner: $owner"
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Safes/Remove-PVSafeOwner.ps1
+++ b/Functions/Safes/Remove-PVSafeOwner.ps1
@@ -66,7 +66,6 @@
 
 			Write-Verbose "Removed Safe Owner: $owner"
 
-
 		}
 
 	}

--- a/Functions/Safes/Reset-PVSafe.ps1
+++ b/Functions/Safes/Reset-PVSafe.ps1
@@ -30,7 +30,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -57,11 +57,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Safe $safe Reset"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Safes/Set-PVSafe.ps1
+++ b/Functions/Safes/Set-PVSafe.ps1
@@ -160,7 +160,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -223,11 +223,11 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Updated Safe $safe"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
+
 
 		}
 

--- a/Functions/Safes/Set-PVSafe.ps1
+++ b/Functions/Safes/Set-PVSafe.ps1
@@ -227,8 +227,6 @@
 
 			Write-Verbose "Updated Safe $safe"
 
-
-
 		}
 
 	}

--- a/Functions/Safes/Set-PVSafeFileCategory.ps1
+++ b/Functions/Safes/Set-PVSafeFileCategory.ps1
@@ -47,7 +47,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -82,8 +82,6 @@
 		elseif($Return -match "True") {
 
 			Write-Verbose "Safe File Category Updated"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Safes/Set-PVSafeNote.ps1
+++ b/Functions/Safes/Set-PVSafeNote.ps1
@@ -36,7 +36,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -64,11 +64,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Note Added to Safe $safe"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Safes/Set-PVSafeOwner.ps1
+++ b/Functions/Safes/Set-PVSafeOwner.ps1
@@ -122,7 +122,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -175,11 +175,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Owner $owner Updated on Safe $safe"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/SessionManagement/New-PVLogonFile.ps1
+++ b/Functions/SessionManagement/New-PVLogonFile.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$logonFile,
 		[Parameter(Mandatory = $False)][string]$username,
@@ -66,11 +66,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Created Logon File $logonFile"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/SessionManagement/New-PVVaultDefinition.ps1
+++ b/Functions/SessionManagement/New-PVVaultDefinition.ps1
@@ -90,7 +90,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$address,
@@ -145,11 +145,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Vault Defined. Name: $vault, Address: $address"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/SessionManagement/Remove-PVVaultDefinition.ps1
+++ b/Functions/SessionManagement/Remove-PVVaultDefinition.ps1
@@ -26,7 +26,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $False)][string]$vault,
 		[Parameter(Mandatory = $False)][int]$sessionID
@@ -50,11 +50,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Definition for Vault $vault Deleted"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/SessionManagementUtilities/Remove-PVCTLCertificate.ps1
+++ b/Functions/SessionManagementUtilities/Remove-PVCTLCertificate.ps1
@@ -29,7 +29,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $False)][string]$ctlFileName,
 		[Parameter(Mandatory = $False)][string]$certFileName,
@@ -54,11 +54,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Certificate $certFileName Deleted from CTL"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Start-PVPacli.ps1
+++ b/Functions/Start-PVPacli.ps1
@@ -26,7 +26,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $False)][int]$sessionID,
 		[Parameter(Mandatory = $False)][string]$ctlFileName
@@ -52,11 +52,9 @@
 
 		}
 
-		Else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Pacli Started"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/Stop-PVPacli.ps1
+++ b/Functions/Stop-PVPacli.ps1
@@ -25,7 +25,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $False)][int]$sessionID
 	)
@@ -50,11 +50,9 @@
 
 		}
 
-		Else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Pacli Stopped"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/New-PVGroup.ps1
+++ b/Functions/UserMangement/New-PVGroup.ps1
@@ -40,7 +40,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -69,11 +69,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Added Group $group"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/New-PVLDAPBranch.ps1
+++ b/Functions/UserMangement/New-PVLDAPBranch.ps1
@@ -43,7 +43,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/New-PVLocation.ps1
+++ b/Functions/UserMangement/New-PVLocation.ps1
@@ -35,7 +35,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -63,11 +63,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Added Location $location"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/New-PVUser.ps1
+++ b/Functions/UserMangement/New-PVUser.ps1
@@ -215,7 +215,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -303,11 +303,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Created Vault User $destUser"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVGroup.ps1
+++ b/Functions/UserMangement/Remove-PVGroup.ps1
@@ -30,7 +30,7 @@
 			LASTEDIT: August 2017
 		#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -56,11 +56,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted Group $group"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVGroupMember.ps1
+++ b/Functions/UserMangement/Remove-PVGroupMember.ps1
@@ -60,11 +60,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted User $member From $group"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVGroupMember.ps1
+++ b/Functions/UserMangement/Remove-PVGroupMember.ps1
@@ -33,7 +33,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Remove-PVLDAPBranch.ps1
+++ b/Functions/UserMangement/Remove-PVLDAPBranch.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Remove-PVLocation.ps1
+++ b/Functions/UserMangement/Remove-PVLocation.ps1
@@ -31,7 +31,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -57,11 +57,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted Location $location"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVSafeGWAccount.ps1
+++ b/Functions/UserMangement/Remove-PVSafeGWAccount.ps1
@@ -62,11 +62,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "$safe Share via $gwAccount Deleted"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVSafeGWAccount.ps1
+++ b/Functions/UserMangement/Remove-PVSafeGWAccount.ps1
@@ -35,7 +35,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Remove-PVUser.ps1
+++ b/Functions/UserMangement/Remove-PVUser.ps1
@@ -30,7 +30,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -59,8 +59,6 @@
 		else {
 
 			Write-Verbose "Deleted User $destUser"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Remove-PVUser.ps1
+++ b/Functions/UserMangement/Remove-PVUser.ps1
@@ -56,7 +56,7 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Deleted User $destUser"
 

--- a/Functions/UserMangement/Rename-PVUser.ps1
+++ b/Functions/UserMangement/Rename-PVUser.ps1
@@ -64,8 +64,6 @@
 
 			Write-Verbose "User Renamed to $newName"
 
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
-
 		}
 
 	}

--- a/Functions/UserMangement/Set-PVGroup.ps1
+++ b/Functions/UserMangement/Set-PVGroup.ps1
@@ -69,11 +69,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Updated Group $group"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Set-PVGroup.ps1
+++ b/Functions/UserMangement/Set-PVGroup.ps1
@@ -40,7 +40,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Set-PVLDAPBranch.ps1
+++ b/Functions/UserMangement/Set-PVLDAPBranch.ps1
@@ -46,7 +46,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Set-PVLocation.ps1
+++ b/Functions/UserMangement/Set-PVLocation.ps1
@@ -35,7 +35,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -66,11 +66,9 @@
 
 		}
 
-		Else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Updated Location $location"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Set-PVUser.ps1
+++ b/Functions/UserMangement/Set-PVUser.ps1
@@ -307,11 +307,9 @@
 
 		}
 
-		Else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Updated User $destUser"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Set-PVUser.ps1
+++ b/Functions/UserMangement/Set-PVUser.ps1
@@ -219,7 +219,7 @@
 		LASTEDIT: August 2017
 	#>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,

--- a/Functions/UserMangement/Set-PVUserPassword.ps1
+++ b/Functions/UserMangement/Set-PVUserPassword.ps1
@@ -33,7 +33,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -75,11 +75,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "Password Updated"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Functions/UserMangement/Set-PVUserPhoto.ps1
+++ b/Functions/UserMangement/Set-PVUserPhoto.ps1
@@ -36,7 +36,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True)][string]$vault,
 		[Parameter(Mandatory = $True)][string]$user,
@@ -64,11 +64,9 @@
 
 		}
 
-		else {
+		elseif($Return.ExitCode -eq 0) {
 
 			Write-Verbose "User Photo Saved to Vault"
-
-			Write-Debug "Command Complete. Exit Code:$($Return.ExitCode)"
 
 		}
 

--- a/Private/ConvertFrom-PacliOutput.ps1
+++ b/Private/ConvertFrom-PacliOutput.ps1
@@ -48,7 +48,7 @@
     #>
 
 	[CmdLetBinding()]
-	[OutputType('System.Array')]
+	[OutputType('System.Object[]')]
 	param(
 		[Parameter(Mandatory = $True, ValueFromPipeline = $True)][string]$pacliOutput,
 		[Parameter(Mandatory = $False, ValueFromPipeline = $False)][string]$regEx = '"([^"]*)"'

--- a/Private/ConvertFrom-PacliOutput.ps1
+++ b/Private/ConvertFrom-PacliOutput.ps1
@@ -48,6 +48,7 @@
     #>
 
 	[CmdLetBinding()]
+	[OutputType('System.Array')]
 	param(
 		[Parameter(Mandatory = $True, ValueFromPipeline = $True)][string]$pacliOutput,
 		[Parameter(Mandatory = $False, ValueFromPipeline = $False)][string]$regEx = '"([^"]*)"'

--- a/Private/ConvertTo-InsecureString.ps1
+++ b/Private/ConvertTo-InsecureString.ps1
@@ -13,6 +13,7 @@ Function ConvertTo-InsecureString {
 	ConvertTo-InsecureString $SecureStringValue
 	#>
 	[CmdLetBinding()]
+	[OutputType('System.String')]
 	Param (
 		[Parameter(Mandatory = $True)]
 		[System.Security.SecureString]$SecureString

--- a/Private/Invoke-PACLICommand.ps1
+++ b/Private/Invoke-PACLICommand.ps1
@@ -28,7 +28,7 @@
     	LASTEDIT: August 2017
     #>
 
-	[CmdLetBinding()]
+	[CmdLetBinding(SupportsShouldProcess)]
 	param(
 		[Parameter(Mandatory = $True, Position = 1)]
 		[string]$PacliEXE,
@@ -47,31 +47,35 @@
 
 	Process {
 
-		Write-Debug "PACLI Command: $PacliCommand $CommandParameters"
+		if ($PSCmdlet.ShouldProcess($PacliEXE, "$PacliCommand $CommandParameters")) {
 
-		#Assign process parameters
-		$PacliProcess.StartInfo.Filename = $PacliEXE
-		$PacliProcess.StartInfo.Arguments = "$PacliCommand $CommandParameters"
-		$PacliProcess.StartInfo.RedirectStandardOutput = $True
-		$PacliProcess.StartInfo.RedirectStandardError = $True
-		$PacliProcess.StartInfo.UseShellExecute = $False
+			Write-Debug "PACLI Command: $PacliCommand $CommandParameters"
 
-		#Start Process
-		$PacliProcess.start()
+			#Assign process parameters
+			$PacliProcess.StartInfo.Filename = $PacliEXE
+			$PacliProcess.StartInfo.Arguments = "$PacliCommand $CommandParameters"
+			$PacliProcess.StartInfo.RedirectStandardOutput = $True
+			$PacliProcess.StartInfo.RedirectStandardError = $True
+			$PacliProcess.StartInfo.UseShellExecute = $False
 
-		#Read Output Stream First
-		$StdOut = $PacliProcess.StandardOutput.ReadToEnd()
-		$StdErr = $PacliProcess.StandardError.ReadToEnd()
+			#Start Process
+			$PacliProcess.start()
 
-		#If you wait for the process to exit before reading StandardOutput
-		#the process can block trying to write to it, so the process never ends.
-		$PacliProcess.WaitForExit()
+			#Read Output Stream First
+			$StdOut = $PacliProcess.StandardOutput.ReadToEnd()
+			$StdErr = $PacliProcess.StandardError.ReadToEnd()
+
+			#If you wait for the process to exit before reading StandardOutput
+			#the process can block trying to write to it, so the process never ends.
+			$PacliProcess.WaitForExit()
+
+			Write-Debug "Exit Code: $($PacliProcess.ExitCode)"
+
+		}
 
 	}
 
 	End {
-
-		Write-Debug "Exit Code: $($PacliProcess.ExitCode)"
 
 		[PSCustomObject] @{
 


### PR DESCRIPTION
PSScriptAnalyzer Rules Implemented:
FIX OutputType Warnings/Recommendations on Clear-PVSafeHistory, ConvertFrom-PacliOutput, ConvertTo-InsecureString.
ADD SupportsShouldProcess to Invoke-PACLICommand: Execution statement now will not run if -whatif specified (message will be displayed detailing Pacli command)
ADD SupportsShouldProcess to all New-PV*, Set-PV*, Start-PV*, Stop-PV*, Remove-PV* & Reset-PV* functions.
RENAME "confirm" parameter on Set-PVRequestStatus function to "confirmRequest"; prevents conflict with PowerShell's confirm parameter. 
Add code to rename "confirmRequest" to "confirm" in the PACLI command