### PR TITLE
New Password Issue Fixed (new line returned)

### DIFF
--- a/Functions/Passwords/New-PVPassword.ps1
+++ b/Functions/Passwords/New-PVPassword.ps1
@@ -129,7 +129,7 @@
 				#Return Generated Password String
 				[PSCustomObject] @{
 
-					"Password" = $Return.StdOut
+					"Password" = $Return.StdOut.TrimEnd()
 
 				}
 


### PR DESCRIPTION
Hi, 

I found an issue when you try create a password, it is created but it contains a new line in addition of the password 

For example: 
$(New-PVPassword -length 8 -minLowerCase 2  -minSpecial -1 -minUpperCase 2 -minDigit 2).Password.Length is equal to 10 instead of 8 as requested 

Regards,