### PR TITLE
Fix data processing

### DIFF
--- a/Private/ConvertFrom-PacliOutput.ps1
+++ b/Private/ConvertFrom-PacliOutput.ps1
@@ -57,7 +57,7 @@
 
 		[Parameter(
 			Mandatory = $False, ValueFromPipeline = $False)]
-		[string]$regEx = '"([^"]*)"'
+		[string]$regEx = '"(.*?)"(?=,|$)'
 	)
 
 	Begin {
@@ -70,7 +70,7 @@
 	Process {
 
 		#remove line break characters in pacli output data,
-		($pacliOutput -replace "\r\n", ""|
+		($pacliOutput -replace "\r\n","," |
 
 			#find all values between quotes
 			Select-String -Pattern $regEx -AllMatches).matches |


### PR DESCRIPTION
Minimal changes to fix problematic behavior.
If a value returned by pacli has a double quote in it, it will cause issues with processing.
The following changes are aimed at fixing that behavior, allowing double quotes in a value.
- Changed regex to match "(.*?)" with a forward look-ahead searching for either a comma, or end of line. Ensuring that we capture the entire value returned from pacli.
- Replace ["\r\n",""] with ["\r\n",","] to allow regex to match all values